### PR TITLE
cmake requires the minimum version command.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.20)
 project(oi.client.rgbd.kinectsdk2 VERSION 0.1 LANGUAGES CXX)
 
 LIST(APPEND CMAKE_MODULE_PATH ${OI_NATIVE_MODULE_PATH} ) 


### PR DESCRIPTION
cmake requires the minimum version command.

```cmake_minimum_required(VERSION 3.20)```